### PR TITLE
fix: deprecate domain sharding

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ func main() {
 That's it at a basic level. More fun features though!
 
 ### Sharding Hosts
+**Warning: Domain Sharding has been deprecated and will be removed in the next major release**<br>
+To find out more, see our [blog post](https://blog.imgix.com/2019/05/03/deprecating-domain-sharding) explaining the decision to remove this feature.
 
 This client supports sharding hosts, by CRC or just by Cycle.
 

--- a/imgix.go
+++ b/imgix.go
@@ -12,10 +12,14 @@ import (
 	"unicode/utf8"
 )
 
+// Deprecated: Domain Sharding has been deprecated and will be removed in the next major release
 type ShardStrategy string
 
 const (
-	ShardStrategyCRC   = ShardStrategy(":crc")
+	// Deprecated: Domain Sharding has been deprecated and will be removed in the next major release
+	ShardStrategyCRC = ShardStrategy(":crc")
+
+	// Deprecated: Domain Sharding has been deprecated and will be removed in the next major release
 	ShardStrategyCycle = ShardStrategy(":cycle")
 )
 
@@ -48,6 +52,8 @@ type Client struct {
 
 // The sharding strategy used by this client.
 // Panics if the sharding strategy is not supported by this library.
+//
+// Deprecated: Domain Sharding has been deprecated and will be removed in the next major release
 func (c *Client) ShardStrategy() ShardStrategy {
 	switch c.shardStrategy {
 	case ShardStrategyCRC, ShardStrategyCycle:
@@ -67,6 +73,8 @@ func (c *Client) Secure() bool {
 
 // Returns a host at the given index.
 // Panics if there are no hosts.
+//
+// Deprecated: Domain Sharding has been deprecated and will be removed in the next major release
 func (c *Client) Hosts(index int) string {
 	if len(c.hosts) == 0 {
 		panic(fmt.Errorf("hosts must be provided"))
@@ -84,6 +92,8 @@ func (c *Client) Scheme() string {
 }
 
 // Returns the host for the given path.
+//
+// Deprecated: Domain Sharding has been deprecated and will be removed in the next major release
 func (c *Client) Host(path string) string {
 	var host string
 	switch c.ShardStrategy() {


### PR DESCRIPTION
This PR begins the process of deprecating, and eventually removing, domain sharding from the imgix-go library.
This PR adds a `deprecation` doc comment to each of the fields and functions that are related to domain sharding. According to the [golang blog](https://blog.golang.org/godoc-documenting-go-code), this seems to be the most idiomatic way to signal a deprecation to developers consuming your package.