### PR TITLE
docs: update vendor name to 'imgix'

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is a Go implementation of an imgix url-building library outlined by
 It's a go package. Do this in your terminal:
 
 ```bash
-go get github.com/parkr/imgix-go
+go get github.com/imgix/imgix-go
 ```
 
 ## Usage
@@ -25,7 +25,7 @@ package main
 import (
     "fmt"
     "net/url"
-    "github.com/parkr/imgix-go"
+    "github.com/imgix/imgix-go"
 )
 
 func main() {


### PR DESCRIPTION
This PR changes the documentation to reflect the correct vendor name for this package.