### PR TITLE
docs: restructure header and add table of contents

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,23 @@
+Copyright (c) 2014, Zebrafish Labs Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
+
+    Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
-# imgix-go
+<!-- ix-docs-ignore -->
+![imgix logo](https://assets.imgix.net/sdk-imgix-logo.svg)
 
-This is a Go implementation of an imgix url-building library outlined by
-[imgix-blueprint](https://github.com/imgix/imgix-blueprint).
+`imgix-go` is a client library for generating image URLs with [imgix](https://www.imgix.com/).
 
-[Godoc](https://godoc.org/github.com/parkr/imgix-go)
+![Version](https://badge.fury.io/gh/imgix%2Fimgix-go.svg)
+[![Build Status](https://travis-ci.org/imgix/imgix-go.svg?branch=master)](https://travis-ci.org/parkr/imgix-go)
+[![Godoc](https://godoc.org/github.com/imgix/imgix-go?status.svg)](https://godoc.org/github.com/imgix/imgix-go)
+[![License](https://img.shields.io/github/license/imgix/imgix-go)](https://github.com/imgix/imgix-go/blob/master/LICENSE)
 
-[![Build Status](https://travis-ci.org/parkr/imgix-go.svg?branch=master)](https://travis-ci.org/parkr/imgix-go)
+---
+<!-- /ix-docs-ignore -->
 
 ## Installation
-
-It's a go package. Do this in your terminal:
 
 ```bash
 go get github.com/imgix/imgix-go
@@ -31,10 +33,8 @@ import (
 func main() {
     client := imgix.NewClient("mycompany.imgix.net")
 
-    // Nothing fancy.
     fmt.Println(client.Path("/myImage.jpg"))
 
-    // Throw some params in there!
     fmt.Println(client.PathWithParams("/myImage.jpg", url.Values{
         "w": []string{"400"},
         "h": []string{"400"},

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@
 ---
 <!-- /ix-docs-ignore -->
 
+- [Installation](#installation)
+- [Usage](#usage)
+
 ## Installation
 
 ```bash
@@ -18,8 +21,6 @@ go get github.com/imgix/imgix-go
 ```
 
 ## Usage
-
-Something like this:
 
 ```go
 package main
@@ -41,5 +42,3 @@ func main() {
     }))
 }
 ```
-
-That's it at a basic level. More fun features though!


### PR DESCRIPTION
This PR restructures the header section of the README, adds more badges, and a table of contents. The header is wrapped in a tag that will exclude it from being displayed on the [imgix libraries](https://docs.imgix.com/libraries) page.

<img width="927" alt="go-readme" src="https://user-images.githubusercontent.com/15919091/70758267-3af73200-1cf7-11ea-84a9-23e42737c574.png">
