### PR TITLE
chore: change refs of master to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 `imgix-go` is a client library for generating image URLs with [imgix](https://www.imgix.com/).
 
 ![Version](https://badge.fury.io/gh/imgix%2Fimgix-go.svg)
-[![Build Status](https://travis-ci.org/imgix/imgix-go.svg?branch=master)](https://travis-ci.org/parkr/imgix-go)
+[![Build Status](https://travis-ci.org/imgix/imgix-go.svg?branch=main)](https://travis-ci.org/parkr/imgix-go)
 [![Godoc](https://godoc.org/github.com/imgix/imgix-go?status.svg)](https://godoc.org/github.com/imgix/imgix-go)
-[![License](https://img.shields.io/github/license/imgix/imgix-go)](https://github.com/imgix/imgix-go/blob/master/LICENSE)
+[![License](https://img.shields.io/github/license/imgix/imgix-go)](https://github.com/imgix/imgix-go/blob/main/LICENSE)
 
 ---
 <!-- /ix-docs-ignore -->


### PR DESCRIPTION
This PR changes any references from the master branch to the main branch, now that it is the default.