### PR TITLE
docs: update travis badge to travis-ci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 `imgix-go` is a client library for generating image URLs with [imgix](https://www.imgix.com/).
 
 ![Version](https://badge.fury.io/gh/imgix%2Fimgix-go.svg)
-[![Build Status](https://travis-ci.org/imgix/imgix-go.svg?branch=main)](https://travis-ci.org/imgix/imgix-go)
+[![Build Status](https://travis-ci.com/imgix/imgix-go.svg?branch=main)](https://travis-ci.com/imgix/imgix-go)
 [![Godoc](https://godoc.org/github.com/imgix/imgix-go?status.svg)](https://godoc.org/github.com/imgix/imgix-go/v2)
 [![License](https://img.shields.io/github/license/imgix/imgix-go)](https://github.com/imgix/imgix-go/blob/main/LICENSE)
 


### PR DESCRIPTION
Updates the travis badge to reflect the status on travis-ci.com