### PR TITLE
fix: dpr srcset when only h param

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,9 +141,9 @@ https://demos.imgix.net/image.png?w=8192&s=1288314bbb33a4f441100b899dd67a00 8192
 
 ### Fixed-Width Images
 
-In cases where enough information is provided about an image's dimensions, `CreateSrcset` will build a srcset that will allow for an image to be served at different resolutions. The parameters taken into consideration when determining if an image is fixed-width are `w`, `h`, and `ar`.
+In cases where enough information is provided about an image's dimensions, `CreateSrcset` will build a srcset that will allow for an image to be served at different resolutions. The parameters taken into consideration when determining if an image is fixed-width are `w` and `h`.
 
-By invoking `CreateSrcset` with either a width **or** the height and aspect ratio in the parameters, a fixed-width srcset will be generated. Wherein, the image width is fixed, but the pixel density varies.
+By invoking `CreateSrcset` with either a width **or** height in the parameters, a fixed-width srcset will be generated. Wherein, the image width is fixed, but the pixel density varies.
 
 ```go
 ub := ix.NewURLBuilder("demo.imgix.net", ix.WithLibParam(false))

--- a/v2/srcset.go
+++ b/v2/srcset.go
@@ -85,7 +85,7 @@ func (b *URLBuilder) CreateSrcset(
 	hasWidth := urlParams.Get("w") != ""
 	hasHeight := urlParams.Get("h") != ""
 
-	// If params has either a width or _both_ height and aspect ratio,
+	// If params has either a width or height,
 	// build a dpr-based srcset attribute.
 	if hasWidth || hasHeight {
 		return b.buildSrcSetDpr(path, urlParams, opts.variableQuality)

--- a/v2/srcset.go
+++ b/v2/srcset.go
@@ -84,11 +84,10 @@ func (b *URLBuilder) CreateSrcset(
 	// Check params contains a width (w) or height (h) _and_ aspect ratio (ar);
 	hasWidth := urlParams.Get("w") != ""
 	hasHeight := urlParams.Get("h") != ""
-	hasAspectRatio := urlParams.Get("ar") != ""
 
 	// If params has either a width or _both_ height and aspect ratio,
 	// build a dpr-based srcset attribute.
-	if hasWidth || (hasHeight && hasAspectRatio) {
+	if hasWidth || hasHeight {
 		return b.buildSrcSetDpr(path, urlParams, opts.variableQuality)
 	}
 

--- a/v2/srcset_test.go
+++ b/v2/srcset_test.go
@@ -73,6 +73,18 @@ func TestURLBuilder_CreateSrcSetFixedHandAR(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
+func TestURLBuilder_CreateSrcSetFixedH(t *testing.T) {
+	c := testClient()
+	params := []IxParam{Param("h", "320")}
+	expected := "https://test.imgix.net/image.png?dpr=1&h=320&q=75 1x,\n" +
+		"https://test.imgix.net/image.png?dpr=2&h=320&q=50 2x,\n" +
+		"https://test.imgix.net/image.png?dpr=3&h=320&q=35 3x,\n" +
+		"https://test.imgix.net/image.png?dpr=4&h=320&q=23 4x,\n" +
+		"https://test.imgix.net/image.png?dpr=5&h=320&q=20 5x"
+	actual := c.CreateSrcset("image.png", params, WithVariableQuality(true))
+	assert.Equal(t, expected, actual)
+}
+
 func TestURLBuilder_CreateSrcsetFixedHandARImplicitVarQuality(t *testing.T) {
 	// Same as above, but omitting WithVariableQuality(true) to show that variable
 	// quality is the implicit-default.

--- a/v2/srcset_test.go
+++ b/v2/srcset_test.go
@@ -1,6 +1,7 @@
 package imgix
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -71,6 +72,19 @@ func TestURLBuilder_CreateSrcSetFixedHandAR(t *testing.T) {
 		"https://test.imgix.net/image.png?ar=4%3A3&dpr=5&h=320&q=20 5x"
 	actual := c.CreateSrcset("image.png", params, WithVariableQuality(true))
 	assert.Equal(t, expected, actual)
+}
+
+func TestURLBuilder_CreateSrcSetFixedHInDprForm(t *testing.T) {
+	c := testClient()
+	params := []IxParam{Param("h", "320")}
+	expected := [5]string{"1x", "2x", "3x", "4x", "5x"}
+	srcset := c.CreateSrcset("image.png", params, WithVariableQuality(true))
+	src := strings.Split(srcset, ",")
+
+	for i := 0; i < len(src); i++ {
+		dpr := strings.Split(src[i], " ")[1]
+		assert.Contains(t, expected, dpr)
+	}
 }
 
 func TestURLBuilder_CreateSrcSetFixedH(t *testing.T) {

--- a/v2/srcset_test.go
+++ b/v2/srcset_test.go
@@ -74,6 +74,20 @@ func TestURLBuilder_CreateSrcSetFixedHandAR(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
+func TestURLBuilder_CreateSrcsetFixedHandARImplicitVarQuality(t *testing.T) {
+	// Same as above, but omitting WithVariableQuality(true) to show that variable
+	// quality is the implicit-default.
+	c := testClient()
+	params := []IxParam{Param("h", "320"), Param("ar", "4:3")}
+	expected := "https://test.imgix.net/image.png?ar=4%3A3&dpr=1&h=320&q=75 1x,\n" +
+		"https://test.imgix.net/image.png?ar=4%3A3&dpr=2&h=320&q=50 2x,\n" +
+		"https://test.imgix.net/image.png?ar=4%3A3&dpr=3&h=320&q=35 3x,\n" +
+		"https://test.imgix.net/image.png?ar=4%3A3&dpr=4&h=320&q=23 4x,\n" +
+		"https://test.imgix.net/image.png?ar=4%3A3&dpr=5&h=320&q=20 5x"
+	actual := c.CreateSrcset("image.png", params)
+	assert.Equal(t, expected, actual)
+}
+
 func TestURLBuilder_CreateSrcSetFixedHInDprForm(t *testing.T) {
 	c := testClient()
 	params := []IxParam{Param("h", "320")}
@@ -96,20 +110,6 @@ func TestURLBuilder_CreateSrcSetFixedH(t *testing.T) {
 		"https://test.imgix.net/image.png?dpr=4&h=320&q=23 4x,\n" +
 		"https://test.imgix.net/image.png?dpr=5&h=320&q=20 5x"
 	actual := c.CreateSrcset("image.png", params, WithVariableQuality(true))
-	assert.Equal(t, expected, actual)
-}
-
-func TestURLBuilder_CreateSrcsetFixedHandARImplicitVarQuality(t *testing.T) {
-	// Same as above, but omitting WithVariableQuality(true) to show that variable
-	// quality is the implicit-default.
-	c := testClient()
-	params := []IxParam{Param("h", "320"), Param("ar", "4:3")}
-	expected := "https://test.imgix.net/image.png?ar=4%3A3&dpr=1&h=320&q=75 1x,\n" +
-		"https://test.imgix.net/image.png?ar=4%3A3&dpr=2&h=320&q=50 2x,\n" +
-		"https://test.imgix.net/image.png?ar=4%3A3&dpr=3&h=320&q=35 3x,\n" +
-		"https://test.imgix.net/image.png?ar=4%3A3&dpr=4&h=320&q=23 4x,\n" +
-		"https://test.imgix.net/image.png?ar=4%3A3&dpr=5&h=320&q=20 5x"
-	actual := c.CreateSrcset("image.png", params)
 	assert.Equal(t, expected, actual)
 }
 


### PR DESCRIPTION
## Description

This PR ensures a DPR-based SrcSet is generated when a fixed height is the only parameter. It also adds a test that ensures the DPR srcset was generated correctly.

## Comments

More tests can be added to ensure this functionality does not conflict with the presence of other params. This should probably be done at a later date.