### PR TITLE
chore: add vscode tasks

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,6 +4,16 @@
   "version": "2.0.0",
   "tasks": [
     {
+      "label": "go: get deps",
+      "type": "shell",
+      "command": "go",
+      "args": ["get","github.com/stretchr/testify", "golang.org/x/tools/cmd/cover"],
+      "group": "test",
+      "problemMatcher": [
+        "$go"
+      ]
+    },
+    {
       "label": "go: fmt",
       "type": "shell",
       "command": "cd ./v2 && go fmt ",
@@ -23,16 +33,6 @@
       },
       "dependsOn": "go: fmt"
       ,
-      "problemMatcher": [
-        "$go"
-      ]
-    },
-    {
-      "label": "go: get deps",
-      "type": "shell",
-      "command": "go",
-      "args": ["get","github.com/stretchr/testify", "golang.org/x/tools/cmd/cover"],
-      "group": "test",
       "problemMatcher": [
         "$go"
       ]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,52 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "go: fmt",
+      "type": "shell",
+      "command": "cd ./v2 && go fmt ",
+      "group": "test",
+      "dependsOn": ["go: get deps"],
+      "problemMatcher": [
+        "$go"
+      ]
+    },
+    {
+      "label": "go: test",
+      "type": "shell",
+      "command": "cd ./v2 && go test -cover",
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      },
+      "dependsOn": "go: fmt"
+      ,
+      "problemMatcher": [
+        "$go"
+      ]
+    },
+    {
+      "label": "go: get deps",
+      "type": "shell",
+      "command": "go",
+      "args": ["get","github.com/stretchr/testify", "golang.org/x/tools/cmd/cover"],
+      "group": "test",
+      "problemMatcher": [
+        "$go"
+      ]
+    },
+    {
+      "label": "go: mod tidy",
+      "type": "shell",
+      "command": "go",
+      "args": [
+        "mod", "tidy"
+      ],
+      "problemMatcher": [
+        "$go"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
# Description

This PR adds Visual Studio Code specific configuration options that make it easier to build and test imgix-go.

- `go: get deps`:  install the project dependencies
- `go: fmt`:  [auto-format](https://blog.golang.org/gofmt) project code
- `go: mod tidy`:  "go mod tidy finds all the packages transitively imported by packages in your module." | [golang docs](https://blog.golang.org/migrating-to-go-modules)
- `go: test`:  run the test suite
  - depends on `fmt` and `deps`, so won't run test suite until those commands have run as well 
  - works in the similar way as the `make` command 
  - with the added benefit of being able to be set as the default vsscode test command