### PR TITLE
chore(vscode): remove deps task

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,21 +4,10 @@
   "version": "2.0.0",
   "tasks": [
     {
-      "label": "go: get deps",
-      "type": "shell",
-      "command": "go",
-      "args": ["get","github.com/stretchr/testify", "golang.org/x/tools/cmd/cover"],
-      "group": "test",
-      "problemMatcher": [
-        "$go"
-      ]
-    },
-    {
       "label": "go: fmt",
       "type": "shell",
       "command": "cd ./v2 && go fmt ",
       "group": "test",
-      "dependsOn": ["go: get deps"],
       "problemMatcher": [
         "$go"
       ]


### PR DESCRIPTION
# Description

Closes #25 

- removes `go: get deps` task that installed now removed library dependencies